### PR TITLE
Improve audio/video detection and playback logic

### DIFF
--- a/composeApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/home/HomePage.kt
+++ b/composeApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/home/HomePage.kt
@@ -589,7 +589,11 @@ fun HomePage(
                                             },
                                             onClick = {
 
-                                                val mediaItem = song.asVideoMediaItem
+                                                val mediaItem = if (song.isAudioOnly == 1)
+                                                    song.asMediaItem
+                                                else
+                                                    song.asVideoMediaItem
+
                                                 binder?.stopRadio()
                                                 binder?.player?.forcePlay(mediaItem)
                                                 //binder?.player?.playOnline(mediaItem)
@@ -651,7 +655,11 @@ fun HomePage(
                                             },
                                             onClick = {
                                                 println("HomePage Clicked on song")
-                                                val mediaItem = song.asVideoMediaItem
+                                                val mediaItem = if (song.isAudioOnly)
+                                                    song.asMediaItem
+                                                else
+                                                    song.asVideoMediaItem
+
                                                 binder?.stopRadio()
                                                 binder?.player?.forcePlay(mediaItem)
                                                 //fastPlay(mediaItem, binder)

--- a/extensions/environment/src/main/kotlin/it/fast4x/environment/utils/FromPlaylistPanelVideoRenderer.kt
+++ b/extensions/environment/src/main/kotlin/it/fast4x/environment/utils/FromPlaylistPanelVideoRenderer.kt
@@ -2,6 +2,7 @@ package it.fast4x.environment.utils
 
 import it.fast4x.environment.Environment
 import it.fast4x.environment.models.PlaylistPanelVideoRenderer
+import it.fast4x.environment.models.WatchEndpoint
 
 fun Environment.SongItem.Companion.from(renderer: PlaylistPanelVideoRenderer): Environment.SongItem? {
 
@@ -10,7 +11,22 @@ fun Environment.SongItem.Companion.from(renderer: PlaylistPanelVideoRenderer): E
         ?.thumbnails
         ?.getOrNull(0)
 
-    val isVideo = (thumbnail?.width ?: 0) > (thumbnail?.height ?: 0)
+    val musicVideoType = renderer
+        .navigationEndpoint
+        ?.watchEndpoint
+        ?.watchEndpointMusicSupportedConfigs
+        ?.watchEndpointMusicConfig
+        ?.musicVideoType
+
+    val isVideoFromType = when (musicVideoType) {
+        WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.MUSIC_VIDEO_TYPE_OMV,
+        WatchEndpoint.WatchEndpointMusicSupportedConfigs.WatchEndpointMusicConfig.MUSIC_VIDEO_TYPE_UGC -> true
+        else -> false
+    }
+
+    // Fallback to thumbnail ratio only when the endpoint does not expose a video type.
+    val isVideoFromThumbnail = musicVideoType == null && (thumbnail?.width ?: 0) > (thumbnail?.height ?: 0)
+    val isVideo = isVideoFromType || isVideoFromThumbnail
 
     return Environment.SongItem(
         info = Environment.Info(


### PR DESCRIPTION
Updated HomePage to select the correct media item type based on the song's audio-only property. Enhanced FromPlaylistPanelVideoRenderer to determine video type using musicVideoType from the endpoint, falling back to thumbnail ratio if unavailable.