### PR TITLE
fix(youtubelogin): use evaluateJavascript instead of loadUrl("javascript:")

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/youtubelogin/YouTubeLogin.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/youtubelogin/YouTubeLogin.kt
@@ -69,8 +69,8 @@ fun YouTubeLogin(
                 WebView(context).apply {
                     webViewClient = object : WebViewClient() {
                         override fun onPageFinished(view: WebView, url: String?) {
-                            loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                            loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
+                            evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
+                            evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
 
                             showConfirmButton = url?.startsWith("https://music.youtube.com") == true
                         }


### PR DESCRIPTION
Closes #246.

`YouTubeLogin.kt` runs script in the login WebView through the legacy form:


`loadUrl(\"javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)\")`
`loadUrl(\"javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)\")`


`loadUrl(\"javascript:...\")\` records a synthetic history entry (so \`goBack()\` can land on it) and has no callback shape. `WebView.evaluateJavascript\` was added in API 19, below the project's minSdk, and does neither.

### Change


`- loadUrl(\"javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)\")`
`- loadUrl(\"javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)\")`
`+ evaluateJavascript(\"Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)\", null)`
`+ evaluateJavascript(\"Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)\", null)`


Both calls fire bridge methods and already discard their results, so passing \`null\` as the callback keeps behaviour identical.