### PR TITLE
fix: YouTube Music login keeps connecting the wrong channel on multi-channel accounts

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/youtubelogin/YouTubeLogin.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/youtubelogin/YouTubeLogin.kt
@@ -1,7 +1,6 @@
 package it.fast4x.riplay.extensions.youtubelogin
 
 import android.webkit.CookieManager
-import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.compose.BackHandler
@@ -41,7 +40,27 @@ import it.fast4x.riplay.utils.restartApp
 import it.fast4x.riplay.utils.typography
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.json.JSONTokener
 import timber.log.Timber
+
+private const val VISITOR_DATA_SCRIPT =
+    "(function() { return window.yt && window.yt.config_ ? window.yt.config_.VISITOR_DATA : null; })()"
+private const val DATA_SYNC_ID_SCRIPT =
+    "(function() { return window.yt && window.yt.config_ ? window.yt.config_.DATASYNC_ID : null; })()"
+
+private fun String?.fromJavascriptString(): String? {
+    val value = this?.takeIf {
+        it.isNotBlank() && it != "null" && it != "undefined"
+    } ?: return null
+
+    val parsedValue = runCatching {
+        JSONTokener(value).nextValue() as? String
+    }.getOrNull() ?: value
+
+    return parsedValue.takeIf {
+        it.isNotBlank() && it != "null" && it != "undefined"
+    }
+}
 
 @Composable
 fun YouTubeLogin(
@@ -66,12 +85,48 @@ fun YouTubeLogin(
                 var visitorData = ""
 
                 WebView(context).apply {
+                    fun refreshYouTubeConfig(onComplete: ((String, String) -> Unit)? = null) {
+                        var refreshedVisitorData = visitorData
+                        var refreshedDataSyncId = dataSyncId
+                        var pendingCallbacks = 2
+
+                        fun completeRefresh() {
+                            pendingCallbacks -= 1
+                            if (pendingCallbacks == 0) {
+                                onComplete?.invoke(refreshedVisitorData, refreshedDataSyncId)
+                            }
+                        }
+
+                        evaluateJavascript(VISITOR_DATA_SCRIPT) { result ->
+                            result.fromJavascriptString()?.let {
+                                visitorData = it
+                                refreshedVisitorData = it
+                            }
+                            completeRefresh()
+                        }
+                        evaluateJavascript(DATA_SYNC_ID_SCRIPT) { result ->
+                            result.fromJavascriptString()?.substringBefore("||")?.takeIf { it.isNotBlank() }?.let {
+                                dataSyncId = it
+                                refreshedDataSyncId = it
+                            }
+                            completeRefresh()
+                        }
+                    }
+
                     webViewClient = object : WebViewClient() {
                         override fun onPageFinished(view: WebView, url: String?) {
-                            evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
-                            evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
+                            refreshYouTubeConfig()
 
                             showConfirmButton = url?.startsWith("https://music.youtube.com") == true
+                        }
+
+                        override fun doUpdateVisitedHistory(
+                            view: WebView,
+                            url: String?,
+                            isReload: Boolean
+                        ) {
+                            super.doUpdateVisitedHistory(view, url, isReload)
+                            refreshYouTubeConfig()
                         }
                     }
 
@@ -87,21 +142,6 @@ fun YouTubeLogin(
                     val cookieManager = CookieManager.getInstance()
                     cookieManager.setAcceptCookie(true)
                     cookieManager.setAcceptThirdPartyCookies(this, true)
-
-                    addJavascriptInterface(object {
-                        @JavascriptInterface
-                        fun onRetrieveVisitorData(newVisitorData: String?) {
-                            if (newVisitorData != null) {
-                                visitorData = newVisitorData
-                            }
-                        }
-                        @JavascriptInterface
-                        fun onRetrieveDataSyncId(newDataSyncId: String?) {
-                            if (newDataSyncId != null) {
-                                dataSyncId = newDataSyncId.substringBefore("||")
-                            }
-                        }
-                    }, "Android")
 
                     webView = this
 
@@ -119,47 +159,49 @@ fun YouTubeLogin(
 
                         Timber.d("YouTubeLogin: User confirmed login.")
 
-                        scope.launch {
-                            delay(200)
-
-                            Timber.d("YouTubeLogin: save login preferences")
-                            context.preferences.edit { putString(YT_VISITOR_DATA.key, visitorData) }
-                            context.preferences.edit { putString(YT_DATA_SYNC_ID.key, dataSyncId) }
-                            context.preferences.edit { putString(YT_COOKIE.key, freshCookie) }
-                            delay(200)
-
-                            Timber.d("YouTubeLogin: Initialize Environment")
-                            Timber.d("YouTubeLogin: freshCookie $freshCookie")
-
-                            Environment.cookie = freshCookie
-                            Environment.dataSyncId = dataSyncId
-                            Environment.visitorData = visitorData
-
-                            Timber.d("YouTubeLogin: Initialized, get account info")
-
-                            Environment.accountInfo().onSuccess {
-                                context.preferences.edit { putString(YT_ACCOUNT_NAME.key, it?.name.orEmpty()) }
-                                context.preferences.edit { putString(YT_ACCOUNT_EMAIL.key, it?.email.orEmpty()) }
-                                context.preferences.edit { putString(YT_ACCOUNT_CHANNEL_HANDLE.key, it?.channelHandle.orEmpty()) }
-                                context.preferences.edit { putString(YT_ACCOUNT_THUMBNAIL.key, it?.thumbnailUrl.orEmpty()) }
+                        refreshYouTubeConfig { refreshedVisitorData, refreshedDataSyncId ->
+                            scope.launch {
                                 delay(200)
 
-                                Timber.d("YouTubeLogin: Logged in as ${it?.name}, restarting app...")
+                                Timber.d("YouTubeLogin: save login preferences")
+                                context.preferences.edit { putString(YT_VISITOR_DATA.key, refreshedVisitorData) }
+                                context.preferences.edit { putString(YT_DATA_SYNC_ID.key, refreshedDataSyncId) }
+                                context.preferences.edit { putString(YT_COOKIE.key, freshCookie) }
+                                delay(200)
 
-                            }.onFailure {
-                                Timber.e(it, "YouTubeLogin: Authentication error")
+                                Timber.d("YouTubeLogin: Initialize Environment")
+                                Timber.d("YouTubeLogin: freshCookie $freshCookie")
+
+                                Environment.cookie = freshCookie
+                                Environment.dataSyncId = refreshedDataSyncId
+                                Environment.visitorData = refreshedVisitorData
+
+                                Timber.d("YouTubeLogin: Initialized, get account info")
+
+                                Environment.accountInfo().onSuccess {
+                                    context.preferences.edit { putString(YT_ACCOUNT_NAME.key, it?.name.orEmpty()) }
+                                    context.preferences.edit { putString(YT_ACCOUNT_EMAIL.key, it?.email.orEmpty()) }
+                                    context.preferences.edit { putString(YT_ACCOUNT_CHANNEL_HANDLE.key, it?.channelHandle.orEmpty()) }
+                                    context.preferences.edit { putString(YT_ACCOUNT_THUMBNAIL.key, it?.thumbnailUrl.orEmpty()) }
+                                    delay(200)
+
+                                    Timber.d("YouTubeLogin: Logged in as ${it?.name}, restarting app...")
+
+                                }.onFailure {
+                                    Timber.e(it, "YouTubeLogin: Authentication error")
+                                }
+
+                                webView.apply {
+                                    stopLoading()
+                                    clearHistory()
+                                    clearCache(true)
+                                    clearFormData()
+                                }
+
+                                Timber.d("YouTubeLogin: Restart app")
+                                restartApp(context)
+
                             }
-
-                            webView.apply {
-                                stopLoading()
-                                clearHistory()
-                                clearCache(true)
-                                clearFormData()
-                            }
-
-                            Timber.d("YouTubeLogin: Restart app")
-                            restartApp(context)
-
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Logging in with a Google account that has multiple YouTube channels (brand accounts) now connects the channel the user actually selects. `VISITOR_DATA` and `DATASYNC_ID` were captured only in `onPageFinished`, but switching channels inside music.youtube.com is a SPA interaction that does not reliably fire that callback, so the confirm button persisted the IDs of the originally loaded channel while the cookie was read fresh, which is the wrong-account symptom in #4.

## Why this matters

The reporter retried disconnect/reconnect and cache clears without success, and the maintainer was actively troubleshooting in the thread without a fix in flight. The mismatch only reproduces with brand accounts, which is why it survived testing with single-channel accounts.

## Changes

- `confirmAction` re-runs the two `evaluateJavascript` captures (via their async result callbacks) so the persisted `YT_VISITOR_DATA` / `YT_DATA_SYNC_ID` reflect the page state at confirm time, keeping the existing `substringBefore("||")` normalization.
- `doUpdateVisitedHistory` re-captures on SPA navigations as a backstop, so channel switches refresh the IDs even before confirm.

## Testing

Single-file change in `YouTubeLogin.kt`; Auto behavior for single-channel accounts is unchanged (the re-capture returns the same values that `onPageFinished` stored). A Gradle compile needs CI since this environment has no Android toolchain for the project.

Fixes #255
