### PR TITLE
Clear Discord presence after paused timeout

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/discord/DiscordPresenceManager.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/discord/DiscordPresenceManager.kt
@@ -69,6 +69,9 @@ class DiscordPresenceManager(
         private const val TEMP_FILE_HOST = "https://litterbox.catbox.moe/resources/internals/api.php"
         private const val MAX_DIMENSION = 1024                           // Per Discord's guidelines
         private const val MAX_FILE_SIZE_BYTES = 2L * 1024 * 1024     // 2 MB in bytes
+        // Clear the Discord presence after this many ms of continuous pause so a
+        // paused activity is not re-asserted forever by the refresh loop (issue #238).
+        private const val PAUSE_CLEAR_TIMEOUT_MS = 5 * 60 * 1000L     // 5 minutes
     }
 
     private var rpc: KizzyRPC? = null
@@ -328,6 +331,10 @@ class DiscordPresenceManager(
             rpc?.closeRPC()
             rpc = KizzyRPC(token)
             lastToken = token
+        } else if (rpc == null) {
+            // The RPC was torn down (e.g. by a prolonged-pause clear); reconnect
+            // so a subsequent play event can re-create the presence cleanly.
+            rpc = KizzyRPC(token)
         }
         val largeImageUrl = getLargeImageUrl(mediaItem.mediaMetadata.artworkUri)
         val smallImageUrl = getSmallImageUrl()
@@ -364,6 +371,25 @@ class DiscordPresenceManager(
         }.onFailure {
             // Log the error but don't show it to the user to avoid disturbance
             Timber.tag("DiscordPresence").w("Error setting Discord activity: ${it.message}")
+        }
+    }
+
+    /**
+     * Clear the current Discord presence by closing the RPC connection.
+     *
+     * Used when a track has been paused for longer than [PAUSE_CLEAR_TIMEOUT_MS]
+     * so a paused activity is not left visible in Discord indefinitely (issue #238).
+     * The next play event re-instantiates [rpc] via the null-guard in [sendActivity].
+     */
+    private fun clearPresence() {
+        if (isStopped) return
+        discordScope.launch {
+            runCatching {
+                rpc?.closeRPC()
+            }.onFailure {
+                Timber.tag("DiscordPresence").w("Error clearing Discord presence: ${it.message}")
+            }
+            rpc = null
         }
     }
 
@@ -434,6 +460,9 @@ class DiscordPresenceManager(
         startTime: Long
     ) {
         refreshJob = discordScope.launch {
+            // Wall-clock time at which the current continuous pause began.
+            // -1 means "not currently paused".
+            var pauseStartedAt = -1L
             while (isActive && !isStopped) {
                 delay(15_000L)
                 if (!isNetworkConnected()) {
@@ -441,10 +470,23 @@ class DiscordPresenceManager(
                 }
                 val isPlaying = isPlayingProvider()
                 if (isPlaying) {
+                    // Resumed: reset the pause timer so only the latest
+                    // continuous pause is measured.
+                    pauseStartedAt = -1L
                     val pos = getCurrentPosition()
                     sendPlayingPresence(mediaItem, pos, duration, startTime)
                 } else {
-                    sendPausedPresence(duration, System.currentTimeMillis(), pausedPosition)
+                    val now = System.currentTimeMillis()
+                    if (pauseStartedAt < 0L) {
+                        pauseStartedAt = now
+                    }
+                    if (now - pauseStartedAt >= PAUSE_CLEAR_TIMEOUT_MS) {
+                        // Paused long enough: clear the presence and stop the
+                        // refresh loop so it is not re-asserted forever (issue #238).
+                        clearPresence()
+                        break
+                    }
+                    sendPausedPresence(duration, now, pausedPosition)
                 }
             }
         }


### PR DESCRIPTION
## Summary

With Discord Rich Presence enabled, pausing a track left the `⏸️ Paused: <title>` presence visible in Discord indefinitely. This adds a 5-minute pause timeout in `DiscordPresenceManager` so a prolonged pause clears the presence instead of re-asserting it forever.

The refresh coroutine in `startRefreshJob` loops every 15s and, while paused, kept calling `sendPausedPresence(...)` with no upper bound, so the paused activity was re-sent for as long as the loop lived. The fix tracks how long the current continuous pause has lasted and, once it crosses `PAUSE_CLEAR_TIMEOUT_MS` (5 minutes), calls a new `clearPresence()` (which closes the RPC connection, the same mechanism already used in `onStop()`) and breaks out of the loop. The pause timer resets on resume, so play -> pause -> play -> pause only measures the latest continuous pause.

To make a later play event reconnect cleanly after a clear, `sendActivity` now re-instantiates `rpc` when it is null (previously it was only re-created on a token change).

The playing path and the 15s refresh cadence are unchanged; brief pauses behave exactly as before.

## Why this matters

The reporter expected the paused presence to disappear after roughly 5 minutes; instead it persisted for hours and even survived the app being closed. The only workaround was disabling RPC in settings and pressing play. This makes the presence self-terminate on a prolonged pause, matching the requested behavior. See https://github.com/fast4x/RiPlay/issues/238.

## Testing

Manual verification path (a headless Android Gradle build was not available in this environment - no JDK/Android SDK - so the change was reviewed against the existing code):

- Play a track, pause, and confirm the presence remains for the first few minutes (short pauses unaffected, 15s cadence unchanged).
- After ~5 minutes of continuous pause, confirm the Discord presence disappears (RPC closed) and the refresh loop has exited (no further paused updates).
- Pause past the timeout so the presence clears, then press play: confirm the presence reappears correctly via the `rpc == null` reconnect guard in `sendActivity`, without toggling the RPC setting.
- Rapid play/pause/play within the window: confirm the pause timer resets on each resume and the presence is not cleared prematurely.

The change is confined to `androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/discord/DiscordPresenceManager.kt` and uses only existing imports and the existing `closeRPC()`/`KizzyRPC(token)` patterns.

Fixes #238
