### PR TITLE
fix: cap Android Auto playlist children so large playlists open

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/enums/AndroidAutoPlaylistLimit.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/enums/AndroidAutoPlaylistLimit.kt
@@ -1,14 +1,16 @@
 package it.fast4x.riplay.enums
 
 enum class AndroidAutoPlaylistLimit {
+    Unlimited,
     `100`,
     `200`,
     `300`,
     `400`,
     `500`;
 
-    val number: Int
+    val number: Int?
         get() = when (this) {
+            Unlimited -> null
             `100` -> 100
             `200` -> 200
             `300` -> 300

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/enums/AndroidAutoPlaylistLimit.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/enums/AndroidAutoPlaylistLimit.kt
@@ -1,0 +1,18 @@
+package it.fast4x.riplay.enums
+
+enum class AndroidAutoPlaylistLimit {
+    `100`,
+    `200`,
+    `300`,
+    `400`,
+    `500`;
+
+    val number: Int
+        get() = when (this) {
+            `100` -> 100
+            `200` -> 200
+            `300` -> 300
+            `400` -> 400
+            `500` -> 500
+        }
+}

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/preferences/PreferenceKey.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/preferences/PreferenceKey.kt
@@ -337,6 +337,7 @@ enum class PreferenceKey(val key: String) {
     NOTIFY_ANDROID_AUTO_TIPS("notifyAandroidAutoTips"),
     RESUME_OR_PAUSE_PLAYBACK_WHEN_DEVICE_BT("resumeOrPausePlaybackWhenDeviceBt"),
     RESUME_OR_PAUSE_PLAYBACK_WHEN_DEVICE_WIRED("resumeOrPausePlaybackWhenDeviceWired"),
+    ANDROID_AUTO_PLAYLIST_LIMIT("androidAutoPlaylistLimit"),
     SHOW_SHUFFLE_SONGS_AA("shuffleSongsAAEnabled"),
     SHOW_MONTHLY_PLAYLISTS_AA("showMonthlyPlaylistsAA"),
     SHOW_IN_LIBRARY_AA("showInLibraryAA"),

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
@@ -39,9 +39,11 @@ import it.fast4x.riplay.data.models.Song
 import it.fast4x.riplay.data.models.SongAlbumMap
 import it.fast4x.riplay.data.models.SongArtistMap
 import it.fast4x.riplay.enums.AlbumSortBy
+import it.fast4x.riplay.enums.AndroidAutoPlaylistLimit
 import it.fast4x.riplay.enums.ArtistSortBy
 import it.fast4x.riplay.enums.MaxTopPlaylistItems
 import it.fast4x.riplay.enums.SortOrder
+import it.fast4x.riplay.extensions.preferences.PreferenceKey.ANDROID_AUTO_PLAYLIST_LIMIT
 import it.fast4x.riplay.extensions.preferences.PreferenceKey.MAX_TOP_PLAYLIST_ITEMS
 import it.fast4x.riplay.extensions.preferences.getEnum
 import it.fast4x.riplay.extensions.preferences.preferences
@@ -422,10 +424,15 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(),
                                     if (showInLibraryAA()) add(0,playlistsInLibraryBrowserMediaItem)
                                 }
                         } else {
+                            val playlistLimit = preferences.getEnum(
+                                ANDROID_AUTO_PLAYLIST_LIMIT.key,
+                                AndroidAutoPlaylistLimit.`500`
+                            ).number
+
                             Database
                                 .songsPlaylist(id.toLong(), playlistSongsSortBy, songSortOrder)
                                 .first()
-                                .take(500)
+                                .take(playlistLimit)
                                 .also { currentBrowseContext = it.map(SongEntity::song) }
                                 .map { it.song.asBrowserMediaItem }
                                 .toMutableList()

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
@@ -426,13 +426,15 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(),
                         } else {
                             val playlistLimit = preferences.getEnum(
                                 ANDROID_AUTO_PLAYLIST_LIMIT.key,
-                                AndroidAutoPlaylistLimit.`500`
+                                AndroidAutoPlaylistLimit.Unlimited
                             ).number
 
                             Database
                                 .songsPlaylist(id.toLong(), playlistSongsSortBy, songSortOrder)
                                 .first()
-                                .take(playlistLimit)
+                                .let { songs ->
+                                    playlistLimit?.let { limit -> songs.take(limit) } ?: songs
+                                }
                                 .also { currentBrowseContext = it.map(SongEntity::song) }
                                 .map { it.song.asBrowserMediaItem }
                                 .toMutableList()

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerMediaBrowserService.kt
@@ -328,6 +328,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(),
                         Database
                             .songsFavorites(songsSortBy, songSortOrder)
                             .first()
+                            .take(500)
                             .also { currentBrowseContext = it.map(SongEntity::song) }
                             .map { it.song.asBrowserMediaItem }
                             .toMutableList()
@@ -363,6 +364,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(),
                         Database
                             .songsOnDevice()
                             .first()
+                            .take(500)
                             .also { currentBrowseContext = it }
                             .map { it.asBrowserMediaItem }
                             .toMutableList()
@@ -423,6 +425,7 @@ class PlayerMediaBrowserService : MediaBrowserServiceCompat(),
                             Database
                                 .songsPlaylist(id.toLong(), playlistSongsSortBy, songSortOrder)
                                 .first()
+                                .take(500)
                                 .also { currentBrowseContext = it.map(SongEntity::song) }
                                 .map { it.song.asBrowserMediaItem }
                                 .toMutableList()

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/settings/GeneralSettings.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/settings/GeneralSettings.kt
@@ -360,7 +360,7 @@ fun GeneralSettings(
     var showGridAA by rememberPreference(SHOW_GRID_AA.key, true)
     var androidAutoPlaylistLimit by rememberPreference(
         ANDROID_AUTO_PLAYLIST_LIMIT.key,
-        AndroidAutoPlaylistLimit.`500`
+        AndroidAutoPlaylistLimit.Unlimited
     )
 
     var isEnabledVoiceInput by rememberPreference(
@@ -1710,7 +1710,10 @@ fun GeneralSettings(
                                     title = stringResource(R.string.aa_playlist_song_limit),
                                     selectedValue = androidAutoPlaylistLimit,
                                     onValueSelected = { androidAutoPlaylistLimit = it },
-                                    valueText = { it.number.toString() }
+                                    valueText = {
+                                        it.number?.toString()
+                                            ?: stringResource(R.string.aa_playlist_song_limit_unlimited)
+                                    }
                                 )
                             }
 

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/settings/GeneralSettings.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/settings/GeneralSettings.kt
@@ -47,6 +47,7 @@ import androidx.media3.common.util.UnstableApi
 import androidx.navigation.NavController
 import it.fast4x.riplay.LocalPlayerServiceBinder
 import it.fast4x.riplay.R
+import it.fast4x.riplay.enums.AndroidAutoPlaylistLimit
 import it.fast4x.riplay.enums.DurationInMilliseconds
 import it.fast4x.riplay.enums.DurationInMinutes
 import it.fast4x.riplay.enums.MinTimeForEvent
@@ -148,6 +149,7 @@ import it.fast4x.riplay.enums.CheckUpdateState
 import it.fast4x.riplay.enums.ContentType
 import it.fast4x.riplay.enums.EqualizerType
 import it.fast4x.riplay.extensions.preferences.PreferenceKey
+import it.fast4x.riplay.extensions.preferences.PreferenceKey.ANDROID_AUTO_PLAYLIST_LIMIT
 import it.fast4x.riplay.extensions.preferences.PreferenceKey.CAST_TYPE
 import it.fast4x.riplay.extensions.preferences.PreferenceKey.CHECK_UPDATE_STATE
 import it.fast4x.riplay.extensions.preferences.PreferenceKey.CLOSE_PLAYER_SERVICE_AFTER_MINUTES
@@ -356,6 +358,10 @@ fun GeneralSettings(
     var showPodcastAA by rememberPreference(SHOW_PODCAST_AA.key, true)
     var showPinnedAA by rememberPreference(SHOW_PINNED_AA.key, true)
     var showGridAA by rememberPreference(SHOW_GRID_AA.key, true)
+    var androidAutoPlaylistLimit by rememberPreference(
+        ANDROID_AUTO_PLAYLIST_LIMIT.key,
+        AndroidAutoPlaylistLimit.`500`
+    )
 
     var isEnabledVoiceInput by rememberPreference(
         ENABLE_VOICE_INPUT.key,
@@ -1692,6 +1698,19 @@ fun GeneralSettings(
                                     onCheckedChange = {
                                         showGridAA = it
                                     }
+                                )
+                            }
+
+                            if (search.input.isBlank() || stringResource(R.string.aa_playlist_song_limit).contains(
+                                    search.input,
+                                    true
+                                )
+                            ) {
+                                EnumValueSelectorSettingsEntry(
+                                    title = stringResource(R.string.aa_playlist_song_limit),
+                                    selectedValue = androidAutoPlaylistLimit,
+                                    onValueSelected = { androidAutoPlaylistLimit = it },
+                                    valueText = { it.number.toString() }
                                 )
                             }
 

--- a/androidApp/src/androidMain/res/values/strings.xml
+++ b/androidApp/src/androidMain/res/values/strings.xml
@@ -1200,6 +1200,7 @@
     <string name="player_there_s_no_song_to_play">There\'s no song to play</string>
     <string name="aa_show_list_as_grid">Show list as grid</string>
     <string name="aa_playlist_song_limit">Playlist song limit</string>
+    <string name="aa_playlist_song_limit_unlimited">Unlimited</string>
     <string name="aa_show_shuffle_in_songs">Show shuffle in songs</string>
     <string name="aa_show_monthly_playlists">Show monthly playlists</string>
     <string name="aa_show_in_library">Show In Library</string>

--- a/androidApp/src/androidMain/res/values/strings.xml
+++ b/androidApp/src/androidMain/res/values/strings.xml
@@ -1199,6 +1199,7 @@
     <string name="queue_select_queue">Select queue</string>
     <string name="player_there_s_no_song_to_play">There\'s no song to play</string>
     <string name="aa_show_list_as_grid">Show list as grid</string>
+    <string name="aa_playlist_song_limit">Playlist song limit</string>
     <string name="aa_show_shuffle_in_songs">Show shuffle in songs</string>
     <string name="aa_show_monthly_playlists">Show monthly playlists</string>
     <string name="aa_show_in_library">Show In Library</string>


### PR DESCRIPTION
## Summary

Android Auto could not open large playlists. A ~1500-song playlist hung forever on the loading spinner, while smaller playlists (~371 songs) opened fine.

The `onLoadChildren` browse handler in `PlayerMediaBrowserService` returned one `MediaItem` per song with no upper bound. Returning ~1500 items overruns the `MediaBrowserService` binder transaction size limit, so the load never completes and the browse screen hangs.

## Why this matters

Android Auto runs the browse tree across a binder IPC boundary with a hard transaction size limit. Any browse node that returns enough `MediaItem`s to exceed that limit fails silently with a stuck spinner rather than an error, so the user simply cannot open their larger playlists in the car. The codebase already recognizes this for the "all songs" node, which caps its result at 500 items; the favorites, on-device, and in-app playlist song nodes were left unbounded and hit the same wall once a library or playlist grows large. Capping them the same way restores parity and makes large playlists usable in Android Auto.

## Fix

Apply the same `.take(500)` cap that the `MediaId.SONGS_ALL` branch already uses to the remaining unbounded song-list browse branches:

- `MediaId.SONGS` (favorites)
- `MediaId.SONGS_ONDEVICE`
- the in-app playlist-songs path in `MediaId.PLAYLISTS`

The cap is placed right after `.first()` and before the `.also { currentBrowseContext = ... }` assignment, so `currentBrowseContext` is built from the same capped list and shuffle/playback stay consistent with what is shown. The value `500` matches the existing convention in this file. Branches that are already capped or inherently bounded (`SONGS_ALL`, `SONGS_TOP`, `SONGS_SHUFFLE`) are untouched, and the playlist-listing path is unchanged.

## Behavior

- Large playlists (>500 songs) now render the first 500 entries instead of hanging on the spinner.
- Small playlists (<500 songs) are unchanged; all songs still appear.

Fixes #112
