### PR TITLE
Fix unsynced lyrics translation second-line interleaving

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/player/common/Lyrics.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/player/common/Lyrics.kt
@@ -51,6 +51,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -706,11 +707,22 @@ fun Lyrics(
 
                     var translatedText by remember { mutableStateOf("") }
                     if (showSecondLine || translateEnabled || romanization != Romanization.Off) {
-                        val mutState = remember { mutableStateOf("") }
-                        // todo  To improve actually not stable
-                        if (translateEnabled)
-                            translateLyrics(mutState, lyricsText, false, languageDestination)
-                        translatedText = mutState.value
+                        val translatedLines = mutableListOf<String>()
+                        val lyricsLines = remember(lyricsText) { lyricsText.lines() }
+                        lyricsLines.forEachIndexed { index, line ->
+                            key(index) {
+                                if (line.isBlank()) {
+                                    translatedLines.add(line)
+                                } else {
+                                    val mutState = remember { mutableStateOf("") }
+                                    // todo  To improve actually not stable
+                                    if (translateEnabled)
+                                        translateLyrics(mutState, line, false, languageDestination)
+                                    translatedLines.add(mutState.value)
+                                }
+                            }
+                        }
+                        translatedText = translatedLines.joinToString("\n")
                     } else { translatedText = lyricsText }
 
                     Column(modifier = Modifier


### PR DESCRIPTION
## Summary

With unsynchronized (plain) lyrics, "Translate" plus "Show Translation in the Second Line" now interleaves each translated line directly below its source line, the same way synchronized (LRC) lyrics already work. Before this change the whole original block showed first and the whole translated block was appended at the end.

## Why this matters

In the unsynchronized branch the translation helper was called once on the entire lyrics blob, so Google returned `<entire source>\n[<entire translation>]` and the second-line interleaving could not apply per line. The synchronized path already calls the helper per sentence, which is why only unsynchronized lyrics showed the block-then-block layout reported in #201.

## Changes

In the unsynchronized branch of `Lyrics.kt`, split `lyricsText` into lines and translate each non-blank line through the existing `translateLyrics` helper, then join the per-line results with newlines. Each line is wrapped in a stable `key(index)` slot so the helper's `remember`/`LaunchedEffect` state is bound per line, matching how the synchronized `itemsIndexed` path works. Blank lines are preserved so verse spacing stays intact. The synchronized path is untouched, and behavior is unchanged when Second Line is off, when Translate is off, and for all romanization variants.

## Testing

This is a Gradle/Android app, so the change was verified by code review and targeted reasoning about the Compose recomposition behavior rather than a full Android build. The fix reuses the existing `translateLyrics` helper unchanged and only restructures how the unsynchronized branch feeds lines into it, so the translation, romanization, and error-fallback logic are identical per line.

Fixes #201
