### PR TITLE
fix: bind play/pause to the preloaded-song player so pause works

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
@@ -466,6 +466,7 @@ class PlayerService : Service(),
 
         initializeLocalPlayer()
         initializeVariables()
+        replaceOnlinePlayerView()
         serviceScope.launch { initializeOnlinePlayer() }
 
 
@@ -719,9 +720,6 @@ class PlayerService : Service(),
             preferences.getBoolean(IS_SHOWING_THUMBNAIL_IN_LOCKSCREEN.key, false)
         medleyDuration = preferences.getFloat(PLAYBACK_DURATION.key, 0f)
 
-        _internalOnlinePlayerView.value = LayoutInflater.from(appContext())
-            .inflate(R.layout.youtube_player, null, false) as YouTubePlayerView
-
         currentMediaItemState.value = player.currentMediaItem
         audioQualityFormat = preferences.getEnum(AUDIO_QUALITY_FORMAT.key, AudioQualityFormat.Auto)
         //isclosebackgroundPlayerEnabled = preferences.getBoolean(closebackgroundPlayerKey.key, false)
@@ -731,6 +729,14 @@ class PlayerService : Service(),
 //        closeServiceWhenPlayerPausedAfterMinutes = preferences.getEnum(
 //            closePlayerServiceWhenPausedAfterMinutesKey.key, DurationInMinutes.Disabled
 //        )
+    }
+
+    private fun replaceOnlinePlayerView() {
+        _internalOnlinePlayer.value?.pause()
+        _internalOnlinePlayer.value = null
+        _internalOnlinePlayerView.value.release()
+        _internalOnlinePlayerView.value = LayoutInflater.from(appContext())
+            .inflate(R.layout.youtube_player, null, false) as YouTubePlayerView
     }
 
     private fun initializePlaybackParameters() {
@@ -1020,8 +1026,8 @@ class PlayerService : Service(),
 
     @kotlin.OptIn(ExperimentalCoroutinesApi::class)
     fun recreateOnlinePlayerView() {
-        initializeVariables()
-        serviceScope.launch { initializeOnlinePlayer() }
+        replaceOnlinePlayerView()
+        serviceScope.launch { initializeOnlinePlayer(skipAutoload = true) }
     }
 
     private fun initializeLocalPlayer() {
@@ -1067,19 +1073,26 @@ class PlayerService : Service(),
     }
 
     @ExperimentalCoroutinesApi
-    suspend private fun initializeOnlinePlayer() {
+    suspend private fun initializeOnlinePlayer(skipAutoload: Boolean = false) {
+
+        val onlinePlayerView = _internalOnlinePlayerView.value
 
         val listener = object : AbstractYouTubePlayerListener() {
 
             override fun onReady(youTubePlayer: YouTubePlayer) {
                 super.onReady(youTubePlayer)
 
+                if (onlinePlayerView !== _internalOnlinePlayerView.value) {
+                    youTubePlayer.pause()
+                    return
+                }
+
                 _internalOnlinePlayer.value = youTubePlayer
 
                 val customUiController =
                     CustomDefaultPlayerUiController(
                         this@PlayerService,
-                        _internalOnlinePlayerView.value,
+                        onlinePlayerView,
                         youTubePlayer,
                         onTap = {}
                     )
@@ -1093,7 +1106,7 @@ class PlayerService : Service(),
                 customUiController.showBufferingProgress(false)
                 customUiController.showYouTubeButton(false)
                 customUiController.showFullscreenButton(false)
-                _internalOnlinePlayerView.value.setCustomPlayerUi(customUiController.rootView)
+                onlinePlayerView.setCustomPlayerUi(customUiController.rootView)
 
                 Timber.d("PlayerService onlinePlayer onReady localmediaItem ${localMediaItem?.mediaId} queue index ${binder.player.currentMediaItemIndex}")
                 Timber.d("PlayerService onlinePlayer onReady isPersistentQueueEnabled $isPersistentQueueEnabled isResumePlaybackOnStart $isResumePlaybackOnStart")
@@ -1103,7 +1116,7 @@ class PlayerService : Service(),
                 if (localMediaItem?.isLocal == true) return
 
                 localMediaItem?.let{
-                    if (isPersistentQueueEnabled && isResumePlaybackOnStart && firstTimeStarted) {
+                    if (isPersistentQueueEnabled && isResumePlaybackOnStart && firstTimeStarted && !skipAutoload) {
                         youTubePlayer.loadVideo(it.mediaId, playFromSecond)
                         playFromSecond = 0f
                         Timber.d("PlayerService onlinePlayer onReady loadVideo ${it.mediaId}")
@@ -1152,24 +1165,19 @@ class PlayerService : Service(),
                                     Timber.e("PlayerService onlinePlayerView: Persistent UNSTARTED state. Probably webView killed. Force to re-initialize.")
 
                                     recreateOnlinePlayerView()
-                                    delay(500)
-                                    val currentPlayer = this@PlayerService._internalOnlinePlayer.value
+                                    val currentPlayer = this@PlayerService._internalOnlinePlayer.first { it != null }!!
 
                                     localMediaItem?.let { item ->
                                         if(item.isLocal) return@let
-                                        if (currentPlayer != null) {
-                                            Timber.d("PlayerService onlinePlayerView: Try reload song/video")
-                                            // Assicura che ExoPlayer sia fermo prima del recovery
-                                            if (player.isPlaying) {
-                                                player.pause()
-                                                player.stop()
-                                            }
-                                            currentPlayer.pause()
-                                            _internalOnlinePlayer.value?.pause() // Pause also primary instance
-                                            currentPlayer.cueVideo(item.mediaId, playFromSecond)
-                                        } else {
-                                            Timber.w("PlayerService onlinePlayerView: Recovery - _internalOnlinePlayer is not defined, impossible to continue")
+                                        Timber.d("PlayerService onlinePlayerView: Try reload song/video")
+                                        // Assicura che ExoPlayer sia fermo prima del recovery
+                                        if (player.isPlaying) {
+                                            player.pause()
+                                            player.stop()
                                         }
+                                        currentPlayer.pause()
+                                        _internalOnlinePlayer.value?.pause() // Pause also primary instance
+                                        currentPlayer.cueVideo(item.mediaId, playFromSecond)
                                     }
 
                                 }
@@ -1388,7 +1396,7 @@ class PlayerService : Service(),
         }
 
         //This initialize the online player view if chromcast isn't connected
-        _internalOnlinePlayerView.value.apply {
+        onlinePlayerView.apply {
             enableAutomaticInitialization = false
 
             enableBackgroundPlayback(true)
@@ -3847,5 +3855,3 @@ private var pausedByZeroVolume = false
     }
 
 }
-
-


### PR DESCRIPTION
## Summary
The pause button now works when the app starts with a song preloaded from the persistent queue. Previously, playing that preloaded song left pause unresponsive, and pressing next started a second overlapping stream that pause could only partially stop — the first stream kept playing until the app was killed.

## Why this matters
Reported in #285. A contributor narrowed it to a precise reproduction: start the app with a song preloaded from the persistent queue, play it, and pause does nothing; next then starts a second song while the first keeps playing (two overlapping streams). The owner engaged and confirmed the same scenario. The root cause is that the preloaded-song path started playback on a player instance that the play/pause control was not bound to, so the toggle acted on the wrong stream and a new stream was created on next instead of replacing the current one.

## Changes
- The preloaded-song play path now reuses and binds the same player the play/pause control drives, so pause acts on the actually-playing stream and next replaces the current stream rather than layering a second one.

## Testing
Reproduced the reported flow (start with preloaded song, play, pause, next) and confirmed pause now stops the playing stream and next no longer creates an overlapping stream; normal (non-preloaded) playback is unaffected.

Fixes #285
