### PR TITLE
fix: crash on NSD onStartDiscoveryFailed calling stopServiceDiscovery with unregistered listener

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/nsd/NsdManager.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/extensions/nsd/NsdManager.kt
@@ -119,13 +119,23 @@ fun discoverNsdServices(
         }
 
         override fun onStartDiscoveryFailed(serviceType: String, errorCode: Int) {
+            // Discovery never started, so this listener was never registered.
+            // Calling stopServiceDiscovery(this) here throws
+            // IllegalArgumentException: listener not registered and crashes the
+            // app (e.g. when resumed from the notification bar with mDNS
+            // unavailable). Only log, matching Google's NsdChat sample.
             Timber.e("NsdManager.discoveryListener Discovery failed: Error code:$errorCode")
-            nsdManager.stopServiceDiscovery(this)
         }
 
         override fun onStopDiscoveryFailed(serviceType: String, errorCode: Int) {
             Timber.e("NsdManager.discoveryListener Discovery failed: Error code:$errorCode")
-            nsdManager.stopServiceDiscovery(this)
+            // Guard against IllegalArgumentException if the listener is not
+            // (or no longer) registered, rather than propagating the crash.
+            try {
+                nsdManager.stopServiceDiscovery(this)
+            } catch (e: IllegalArgumentException) {
+                Timber.e("NsdManager.discoveryListener stopServiceDiscovery failed: ${e.localizedMessage}")
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Opening RiPlay from the notification bar can crash the app with `IllegalArgumentException: listener not registered`. This is a small defensive fix in the NSD discovery listener that stops the crash on the failed-to-start discovery path.

## Background

The reported crash comes from `discoverNsdServices` in `NsdManager.kt`. The discovery listener's `onStartDiscoveryFailed` override calls `nsdManager.stopServiceDiscovery(this)`:

```
java.lang.IllegalArgumentException: listener not registered
    at android.net.nsd.NsdManager.getListenerKey(NsdManager.java:467)
    at android.net.nsd.NsdManager.stopServiceDiscovery(NsdManager.java:601)
    at it.fast4x.riplay.extensions.nsd.NsdManagerKt$discoverNsdServices$discoveryListener$1.onStartDiscoveryFailed(SourceFile:20)
```

When `onStartDiscoveryFailed` fires, discovery never started and the listener was never successfully registered, so per the Android NSD contract `stopServiceDiscovery(this)` throws `IllegalArgumentException: listener not registered` and crashes the app. This is reproducible when discovery cannot start, for example when mDNS is unavailable as the app is resumed from the notification bar.

## The fix

Confined to the NSD discovery listener in `NsdManager.kt`:

- Remove the `stopServiceDiscovery(this)` call from `onStartDiscoveryFailed`, leaving only the error log. This matches Google's official NsdChat sample, which only logs in that callback because there is nothing registered to stop.
- Wrap the `stopServiceDiscovery(this)` call in `onStopDiscoveryFailed` in a try/catch so the analogous "listener not registered" case logs instead of propagating the crash.

Normal discovery lifecycle (`onDiscoveryStarted` -> `onServiceFound` -> resolve) is unaffected; the removed call only ran on the failed-to-start path.

Fixes #291
