### PR TITLE
fix: keep synchronized lyrics scrolling during playback

### DIFF
--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -123,6 +123,12 @@ kotlin {
         implementation(libs.zxing.core)
 
     }
+
+    sourceSets {
+        androidUnitTest.dependencies {
+            implementation(kotlin("test"))
+        }
+    }
 }
 
 val localProperties = Properties()

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/player/common/Lyrics.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/ui/screens/player/common/Lyrics.kt
@@ -151,6 +151,7 @@ import it.fast4x.riplay.utils.typography
 import it.fast4x.riplay.ui.components.themed.LyricsSizeDialog
 import it.fast4x.riplay.utils.applyIf
 import it.fast4x.riplay.ui.styling.ColorPalette
+import it.fast4x.riplay.utils.LatestValueProvider
 import it.fast4x.riplay.utils.SynchronizedLyricsLines
 import it.fast4x.riplay.utils.playNext
 import it.fast4x.riplay.utils.playPrevious
@@ -211,7 +212,8 @@ fun Lyrics(
     val appSettings = appSettingsManager.activeSettings.collectAsStateWithLifecycle().value
 
     val (currentPosition, duration) = rememberPlayerPositionAndDuration(binder)
-    val positionProvider = { currentPosition }
+    val positionProvider = remember { LatestValueProvider(currentPosition) }
+    positionProvider.value = currentPosition
     //Timber.d("LyricsNew positionAndDuration ${positionAndDuration.first}")
 
     val showlyricsthumbnail = appearanceSettings.showLyricsThumbnail
@@ -538,7 +540,7 @@ fun Lyrics(
                         else LRCLyricsKaraokeParser
                             .parse(currentLyrics?.lrcSynced ?: "", isOnline = binder?.player?.currentMediaItem?.isLocal == true)
                         invalidLrc = false
-                        SynchronizedLyricsLines(sentences) { positionProvider() }
+                        SynchronizedLyricsLines(sentences, positionProvider)
                     }
 
                     val lazyListState = rememberLazyListState()

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/utils/LyricsUtils.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/utils/LyricsUtils.kt
@@ -17,6 +17,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlin.time.Duration.Companion.milliseconds
 
+class LatestValueProvider<T>(initialValue: T) : () -> T {
+    var value: T = initialValue
+
+    override fun invoke(): T = value
+}
+
 class SynchronizedLyricsLines(val sentences: List<LRCLyricLine>, private val positionProvider: () -> Long) {
     var index by mutableStateOf(currentIndex)
         private set

--- a/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/utils/LatestValueProviderTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/utils/LatestValueProviderTest.kt
@@ -1,0 +1,28 @@
+package it.fast4x.riplay.utils
+
+import it.fast4x.riplay.extensions.lyricshelper.models.LRCLyricLine
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LatestValueProviderTest {
+    @Test
+    fun synchronizedLyricsUsesPlaybackPositionUpdatesAfterInitialization() {
+        val positionProvider = LatestValueProvider(1_000L)
+        val lyrics = SynchronizedLyricsLines(
+            sentences = listOf(
+                LRCLyricLine(timeMs = 0L, text = "first"),
+                LRCLyricLine(timeMs = 10_000L, text = "second"),
+                LRCLyricLine(timeMs = 20_000L, text = "third"),
+            ),
+            positionProvider = positionProvider,
+        )
+
+        assertEquals(0, lyrics.index)
+
+        positionProvider.value = 15_000L
+
+        assertTrue(lyrics.update())
+        assertEquals(1, lyrics.index)
+    }
+}


### PR DESCRIPTION
## Summary

- Keep a stable playback-position provider for the remembered synchronized-lyrics state.
- Refresh the provider value as the Compose playback position changes.
- Add a regression test proving that an existing `SynchronizedLyricsLines` instance observes later position updates.

## Problem

When synchronized line-by-line lyrics are opened, the view initially jumps to the current line. The remembered lyrics object can then retain the playback position captured during its creation, so the active line and list stop advancing while playback continues.

## Fix

The remembered `SynchronizedLyricsLines` instance now receives a stable callable provider. Its value is refreshed during recomposition, allowing the existing polling loop to observe the latest playback position and continue scrolling.

## Testing

- Confirmed the regression test fails before the production fix.
- Confirmed the focused regression test passes after the fix.
- `testFossDebugUnitTest` passes.
- `assembleFossDebug` passes.
- Verified on a Pixel 8 Pro running Android 16 with RiPlay 0.7.88 and “Forever Young” by Alphaville.

Local dependency-resolution adjustments needed to build the current repository snapshot were intentionally excluded from this PR.

## Scope

This PR only fixes synchronized line-by-line lyrics stopping after the initial jump. It does not change LRC timestamps, lyric offsets, provider selection, or word-by-word lyrics.

Fixes #356
