### PR TITLE
fix: keep player metadata in sync on track changes

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
@@ -227,7 +227,6 @@ import kotlin.time.Duration.Companion.seconds
 import android.os.Binder as AndroidBinder
 import it.fast4x.riplay.extensions.appsettings.AppSettingsManager
 import it.fast4x.riplay.extensions.experimental.webdavlibrary.models.WebDavConfig
-import it.fast4x.riplay.services.playback.common.MediaInfo
 import it.fast4x.riplay.services.playback.common.PlaybackContext
 import it.fast4x.riplay.services.playback.common.PlaybackState
 import it.fast4x.riplay.services.playback.common.PlayerState
@@ -558,8 +557,9 @@ class PlayerService : MediaLibraryService(),
         }
 
         serviceScope.launch {
-            currentSong.collect(serviceScope) { song ->
+            currentSong.collect { song ->
                 if (song == null) return@collect
+                if (currentMediaItemState.value?.mediaId != song.id) return@collect
 
                 Timber.d("PlayerService onCreate update currentSong $song mediaItemState ${currentMediaItemState.value}")
 
@@ -615,13 +615,11 @@ class PlayerService : MediaLibraryService(),
 
                 withContext(Dispatchers.Main) {
                     _playerState.update { currentState ->
-                        currentState.copy(
-                            mediaInfo = MediaInfo(
-                                mediaItem = song.asMediaItem,
-                                queueIndex = player.currentMediaItemIndex,
-                                queueSize = player.mediaItems.size
-                            ),
-                            errorMessage = null,
+                        currentState.withDatabaseMediaItemIfCurrent(
+                            currentMediaId = currentMediaItemState.value?.mediaId,
+                            databaseMediaItem = song.asMediaItem,
+                            queueIndex = player.currentMediaItemIndex,
+                            queueSize = player.mediaItemCount,
                         )
                     }
                 }
@@ -2183,8 +2181,6 @@ private fun updateOnlineNearEndTicks() {
             recordListeningEvent(mediaItem.mediaId)
         }
 
-        currentMediaItemState.value = mediaItem
-        localMediaItem = mediaItem
         _internalOnlinePlayer.value?.pause() // stop online player latency
 
         _currentSecond.value = 0F
@@ -2222,6 +2218,16 @@ private fun updateOnlineNearEndTicks() {
             SmartMessage(getString(R.string.warning_skipped_blacklisted_song), context = this@PlayerService)
             return
         }
+
+        currentMediaItemState.value = mediaItem
+        _playerState.update { state ->
+            state.withMediaTransition(
+                mediaItem = mediaItem,
+                queueIndex = player.currentMediaItemIndex,
+                queueSize = player.mediaItemCount,
+            )
+        }
+        localMediaItem = mediaItem
 
         mediaItem.let {
 

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/common/PlayerState.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/common/PlayerState.kt
@@ -11,6 +11,34 @@ data class PlayerState(
 ) {
     val isPlaying: Boolean
         get() = playbackState == PlaybackState.PLAYING
+
+    fun withMediaTransition(
+        mediaItem: MediaItem,
+        queueIndex: Int,
+        queueSize: Int,
+    ): PlayerState = copy(
+        mediaInfo = MediaInfo(
+            mediaItem = mediaItem,
+            queueIndex = queueIndex,
+            queueSize = queueSize,
+        ),
+        errorMessage = null,
+    )
+
+    fun withDatabaseMediaItemIfCurrent(
+        currentMediaId: String?,
+        databaseMediaItem: MediaItem,
+        queueIndex: Int,
+        queueSize: Int,
+    ): PlayerState = if (currentMediaId == databaseMediaItem.mediaId) {
+        withMediaTransition(
+            mediaItem = databaseMediaItem,
+            queueIndex = queueIndex,
+            queueSize = queueSize,
+        )
+    } else {
+        this
+    }
 }
 
 data class PlayerSettings(

--- a/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/services/playback/common/PlayerStateTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/services/playback/common/PlayerStateTest.kt
@@ -1,0 +1,83 @@
+package it.fast4x.riplay.services.playback.common
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PlayerStateTest {
+    @Test
+    fun staleDatabaseResultDoesNotOverwriteNewTransition() {
+        val oldDatabaseItem = MediaItem.Builder()
+            .setMediaId("previous-id")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("Big in Japan")
+                    .setArtist("Alphaville")
+                    .build()
+            )
+            .build()
+        val currentItem = MediaItem.Builder()
+            .setMediaId("next-id")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("Take On Me")
+                    .setArtist("a-ha")
+                    .build()
+            )
+            .build()
+        val currentState = PlayerState(
+            mediaInfo = MediaInfo(currentItem, queueIndex = 1, queueSize = 94),
+        )
+
+        val updatedState = currentState.withDatabaseMediaItemIfCurrent(
+            currentMediaId = currentItem.mediaId,
+            databaseMediaItem = oldDatabaseItem,
+            queueIndex = 1,
+            queueSize = 94,
+        )
+
+        assertEquals("next-id", updatedState.mediaInfo?.mediaItem?.mediaId)
+        assertEquals("Take On Me", updatedState.mediaInfo?.mediaItem?.mediaMetadata?.title)
+    }
+
+    @Test
+    fun mediaTransitionReplacesStaleUiMetadataWithoutDatabaseRow() {
+        val previousItem = MediaItem.Builder()
+            .setMediaId("previous-id")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("Big in Japan")
+                    .setArtist("Alphaville")
+                    .build()
+            )
+            .build()
+        val nextItem = MediaItem.Builder()
+            .setMediaId("next-id")
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setTitle("Take On Me")
+                    .setArtist("a-ha")
+                    .build()
+            )
+            .build()
+        val staleState = PlayerState(
+            mediaInfo = MediaInfo(previousItem, queueIndex = 0, queueSize = 94),
+            errorMessage = "stale error",
+        )
+
+        val updatedState = staleState.withMediaTransition(
+            mediaItem = nextItem,
+            queueIndex = 1,
+            queueSize = 94,
+        )
+
+        assertEquals("next-id", updatedState.mediaInfo?.mediaItem?.mediaId)
+        assertEquals("Take On Me", updatedState.mediaInfo?.mediaItem?.mediaMetadata?.title)
+        assertEquals("a-ha", updatedState.mediaInfo?.mediaItem?.mediaMetadata?.artist)
+        assertEquals(1, updatedState.mediaInfo?.queueIndex)
+        assertEquals(94, updatedState.mediaInfo?.queueSize)
+        assertNull(updatedState.errorMessage)
+    }
+}


### PR DESCRIPTION
## Summary

Fix stale player metadata after track changes.

The audio playback and both Android media sessions could already move to the next track while the visible RiPlay player continued showing metadata from the previous track.

Fixes #347.

## Root cause

`UnifiedPlayer` renders `playerState.mediaInfo`, while the Android media sessions use `player.currentMediaItem`.

After a media item transition, `playerState.mediaInfo` was only updated by the database-backed `currentSong` collector. If the new media item did not yet have a matching row in the `Song` table, the flow emitted `null` and the previous UI metadata remained unchanged.

A delayed database result from the previous item could also update the state after a later transition.

## Changes

- Publish an accepted transition `MediaItem` to `playerState.mediaInfo` immediately.
- Perform duplicate, parental-control, video-exclusion, and blacklist checks before publishing the item as active UI state.
- Ignore database metadata whose media ID no longer matches the current media item.
- Recheck the media ID immediately before applying database-enriched metadata.
- Add regression tests for:
  - a transition to an item without a database row;
  - a delayed database result from the previous item.

## Verification

- Targeted regression tests passed (2 tests, 0 failures).
- `:androidApp:testFossDebugUnitTest` passed.
- `:androidApp:assembleFossDebug` passed.
- Tested with RiPlay 0.7.89 on a Pixel 8 Pro running Android 16.
- Original reproduced mismatch:
  - visible UI: `Big in Japan` — Alphaville;
  - both RiPlay media sessions: `Take On Me` — a-ha.
- The final hardened build was verified with five consecutive manual track changes.
- At the final capture, the visible UI and both RiPlay media sessions agreed on `Rock With You` — Michael Jackson, with playback active.

## Scope

This PR only addresses player metadata synchronization. It does not include APKs, logs, screenshots, local build workarounds, lyric changes, or unrelated cleanup.
