### PR TITLE
fix: preserve user volume after activity resume

### DIFF
--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/MainActivity.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/MainActivity.kt
@@ -216,6 +216,9 @@ class MainActivity : AppCompatActivity() {
             if (service is PlayerService.Binder) {
                 this@MainActivity.binder = service
                 service.cancelTimer() // cancel sleep timer when service is connected, before app was closed
+                if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+                    service.restoreUserVolume()
+                }
             }
 
         }
@@ -1613,7 +1616,7 @@ class MainActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
 
-        binder?.onlinePlayer?.setVolume(100) // maybe is needed when webview lost audiofocus
+        binder?.restoreUserVolume()
 
         //preferences.edit(commit = true) { putBoolean(APP_IS_RUNNING.key, true) }
 
@@ -1664,6 +1667,7 @@ class MainActivity : AppCompatActivity() {
         }.onFailure {
             Timber.e("MainActivity.onStop unbindService ${it.stackTraceToString()}")
         }
+        binder = null
 
     }
 

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/PlayerService.kt
@@ -230,6 +230,7 @@ import it.fast4x.riplay.extensions.experimental.webdavlibrary.models.WebDavConfi
 import it.fast4x.riplay.services.playback.common.PlaybackContext
 import it.fast4x.riplay.services.playback.common.PlaybackState
 import it.fast4x.riplay.services.playback.common.PlayerState
+import it.fast4x.riplay.services.playback.common.restorePlayerVolume
 import it.fast4x.riplay.utils.BitmapLoader
 import it.fast4x.riplay.utils.CryptoManager
 import it.fast4x.riplay.utils.forcePlayAtIndex
@@ -4000,6 +4001,17 @@ private fun updateOnlineNearEndTicks() {
 
         val currentMediaItemAsSong: Song?
             get() = this@PlayerService.player.currentMediaItem?.asSong
+
+        fun restoreUserVolume() {
+            if (!_isServiceReady.value || !this@PlayerService::hybridPlayer.isInitialized) return
+            val currentSettings = appSettingsManager.activeSettings.value
+            restorePlayerVolume(
+                userVolume = currentSettings.userVolume,
+                isFading = isFading,
+                isServiceReady = true,
+                setVolume = hybridPlayer::setVolume,
+            )
+        }
 
         val riTuneCastClient: RiTuneCastClient
             @Synchronized

--- a/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/common/PlayerVolume.kt
+++ b/androidApp/src/androidMain/kotlin/it/fast4x/riplay/services/playback/common/PlayerVolume.kt
@@ -1,0 +1,11 @@
+package it.fast4x.riplay.services.playback.common
+
+fun restorePlayerVolume(
+    userVolume: Float,
+    isFading: Boolean,
+    isServiceReady: Boolean,
+    setVolume: (Float) -> Unit,
+) {
+    if (isFading || !isServiceReady) return
+    setVolume(userVolume.coerceIn(0f, 1f))
+}

--- a/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/services/playback/common/PlayerVolumeTest.kt
+++ b/androidApp/src/androidUnitTest/kotlin/it/fast4x/riplay/services/playback/common/PlayerVolumeTest.kt
@@ -1,0 +1,42 @@
+package it.fast4x.riplay.services.playback.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlayerVolumeTest {
+    @Test
+    fun storedVolumeIsRestoredAfterActivityResume() {
+        var appliedVolume = -1f
+
+        restorePlayerVolume(0.48f, isFading = false, isServiceReady = true) { appliedVolume = it }
+
+        assertEquals(0.48f, appliedVolume)
+    }
+
+    @Test
+    fun volumeIsNotOverwrittenWhileFadeIsRunning() {
+        var applyCount = 0
+
+        restorePlayerVolume(0.48f, isFading = true, isServiceReady = true) { applyCount++ }
+
+        assertEquals(0, applyCount)
+    }
+
+    @Test
+    fun restoredVolumeIsClampedToPlayerRange() {
+        var appliedVolume = -1f
+
+        restorePlayerVolume(1.5f, isFading = false, isServiceReady = true) { appliedVolume = it }
+
+        assertEquals(1f, appliedVolume)
+    }
+
+    @Test
+    fun volumeIsNotRestoredThroughStoppedService() {
+        var applyCount = 0
+
+        restorePlayerVolume(0.48f, isFading = false, isServiceReady = false) { applyCount++ }
+
+        assertEquals(0, applyCount)
+    }
+}


### PR DESCRIPTION
## Summary

Preserve the user's playback volume when RiPlay resumes after an external Android activity.

Fixes #363.

## Problem

`MainActivity.onResume()` unconditionally set the internal online player to 100%:

```kotlin
binder?.onlinePlayer?.setVolume(100)
```

Returning from DocumentsUI or another external activity therefore made online playback noticeably louder even though Android's `STREAM_MUSIC` value, output device, and audio focus had not changed. Pressing a hardware volume key restored the expected value through RiPlay's volume observer.

## Changes

- Restore the current saved user volume through `HybridPlayer` instead of setting the online player to 100%.
- Clear the Activity's Binder reference after unbinding.
- Restore volume after delayed service reconnection if `onResume()` already ran.
- Read the current settings value at invocation time.
- Guard service readiness and `HybridPlayer` initialization.
- Avoid overwriting an active fade.
- Add regression tests for restoration, clamping, fade protection, and stopped-service protection.

## Verification

- Regression test was RED before the restoration helper existed and GREEN afterward.
- 4 targeted regression tests passed.
- `:androidApp:testFossDebugUnitTest` passed.
- `:androidApp:assembleFossDebug` passed.
- Two independent code-review passes found no remaining security or logic errors.
- Tested on RiPlay 0.7.89 with a Pixel 8 Pro running Android 16.
- Original capture: Android `STREAM_MUSIC` remained `12/25` before, during, and after DocumentsUI while perceived playback became louder.
- Final hardened combined build: returning from the same DocumentsUI flow left perceived volume unchanged.

## Scope

This PR only addresses volume restoration across Activity resume and associated Binder lifecycle safety. It contains no APKs, logs, screenshots, local build workarounds, metadata changes, or unrelated cleanup.
